### PR TITLE
#166287 Add is_cant_refresh property to BitrixApiError

### DIFF
--- a/bitrix24/exceptions.py
+++ b/bitrix24/exceptions.py
@@ -89,6 +89,10 @@ class BitrixApiError(BitrixApiException):
         return self.error == 'authorization_error'
 
     @property
+    def is_cant_refresh(self):
+        return self.error == 'expired_token' and self.message == 'cant_refresh'
+
+    @property
     def is_free_plan_error(self):
         return self.error_description == "REST is available only on commercial plans."
 


### PR DESCRIPTION
**Забыли сделать этот мерж вместе с мержем изменений в bitrix_utils.**
Нужен для того, чтобы работало использование BitrixApiError.is_cant_refresh в bitrix_utils!
Сейчас уже есть ошибки из-за этого в AbsPortalEventSetting.