### PR TITLE
#189991 Опциональная валидация параметров, присылаемых Битриксом в BaseBitrixRobot

### DIFF
--- a/bitrix_robots/base.py
+++ b/bitrix_robots/base.py
@@ -308,7 +308,7 @@ class BaseBitrixRobot(models.Model):
             try:
                 return int(value)
             except ValueError:
-                raise ValidationError(f"Значение '{value}' не может быть преобразовано в число.")
+                raise ValidationError(f'Значение "{value}" не может быть преобразовано в число.')
 
         # Если значение ни строка, ни число – выбрасываем ошибку валидации
         raise ValidationError('Значение должно быть строкой или числом.')
@@ -332,11 +332,11 @@ class BaseBitrixRobot(models.Model):
                     self.props[prop_name] = self.safe_int(prop_value)
 
             except ValidationError as exc:
-                errors.append(f"Ошибка в поле '{prop_name}': {exc}")
+                errors.append(f'Ошибка в поле "{prop_name}": {exc.message}.')
 
         if errors:
             # Если есть хотя бы одна ошибка, выбрасываем их все одним исключением
-            raise ValidationError('\n'.join(errors))
+            raise ValidationError(' '.join(errors))
 
         return self.props
 
@@ -404,6 +404,8 @@ class BaseBitrixRobot(models.Model):
 
     @staticmethod
     def get_error_result(exc: Exception) -> dict:
+        if hasattr(exc, 'message'):
+            return dict(error=exc.message)
         return dict(error=str(exc))
 
     def get_return_values(self) -> dict:

--- a/bitrix_robots/base.py
+++ b/bitrix_robots/base.py
@@ -280,7 +280,8 @@ class BaseBitrixRobot(models.Model):
         return auth
 
     def verify_event(self):
-        """Проверка подлинности присланного события.
+        """
+        Проверка подлинности присланного события.
         Несколько усложняется тем, что у нас несколько приложений Базы Знаний.
 
         :raises: VerificationError
@@ -344,7 +345,8 @@ class BaseBitrixRobot(models.Model):
 
     @cached_property
     def props(self) -> dict:
-        """Разбирает присланные данные на основании PROPERTIES
+        """
+        Разбирает присланные данные на основании PROPERTIES
         """
 
         if self.is_hook_request:

--- a/bitrix_robots/base.py
+++ b/bitrix_robots/base.py
@@ -99,7 +99,8 @@ class BaseBitrixRobot(models.Model):
 
     @classmethod
     def handler_url(cls, view_name):
-        """Получить URL обработчика через reverse+название view
+        """
+        Получить URL обработчика через reverse+название view
         """
         return 'https://{domain}{path}'.format(
             domain=cls.APP_DOMAIN,
@@ -139,21 +140,21 @@ class BaseBitrixRobot(models.Model):
 
     @classmethod
     def is_installed(cls, admin_token: 'BitrixUserToken') -> bool:
-        """Зарегистрирован ли робот на портале
+        """
+        Зарегистрирован ли робот на портале
         """
         robot_codes = admin_token.call_list_method_v2('bizproc.robot.list')
         return any(code == cls.CODE for code in robot_codes)
 
     @classmethod
-    def install(cls, view_name: str, admin_token: 'BitrixUserToken',
-                token_user: Optional['BitrixUser'] = None):
-        """Встроить робота на портал
+    def install(cls, view_name: str, admin_token: 'BitrixUserToken', token_user: Optional['BitrixUser'] = None):
+        """
+        Встроить робота на портал
         """
         if token_user:
             assert token_user.id == admin_token.user_id
         else:
             token_user = admin_token.user
-
         return admin_token.call_api_method(
             'bizproc.robot.add',
             params=cls._robot_add_params(view_name, token_user.bitrix_id),
@@ -161,39 +162,37 @@ class BaseBitrixRobot(models.Model):
 
     @classmethod
     def uninstall(cls, admin_token: 'BitrixUserToken'):
-        """Удалить робота с портала
         """
-
+        Удалить робота с портала
+        """
         return admin_token.call_api_method(
             'bizproc.robot.delete',
             params=dict(CODE=cls.CODE),
         )['result']
 
     @classmethod
-    def update(cls, view_name: str, admin_token: 'BitrixUserToken',
-               token_user: Optional['BitrixUser'] = None):
-        """Обновить параметры робота на портале
+    def update(cls, view_name: str, admin_token: 'BitrixUserToken', token_user: Optional['BitrixUser'] = None):
+        """
+        Обновить параметры робота на портале
         """
         if token_user:
             assert token_user.id == admin_token.user_id
         else:
             token_user = admin_token.user
-
         return admin_token.call_api_method(
             'bizproc.robot.update',
             params=cls._robot_update_params(view_name, token_user.bitrix_id),
         )['result']
 
     @classmethod
-    def install_or_update(cls, view_name: str, admin_token: 'BitrixUserToken',
-                          token_user: 'BitrixUser' = None):
-        """Встроить или обновить параметры робота на портале
+    def install_or_update(cls, view_name: str, admin_token: 'BitrixUserToken', token_user: 'BitrixUser' = None):
+        """
+        Встроить или обновить параметры робота на портале
         """
         if cls.is_installed(admin_token):
             method = cls.update
         else:
             method = cls.install
-
         return method(view_name=view_name, admin_token=admin_token, token_user=token_user)
 
     @classmethod

--- a/bitrix_robots/base.py
+++ b/bitrix_robots/base.py
@@ -377,10 +377,10 @@ class BaseBitrixRobot(models.Model):
         self.started = timezone.now()
         self.save(update_fields=['started'])
 
-        if self.VALIDATE_PROPS:
-            self.validate_props()
-
         try:
+            if self.VALIDATE_PROPS:
+                self.validate_props()
+
             self.result = self.process()
             self.is_success = True
 

--- a/bitrix_robots/base.py
+++ b/bitrix_robots/base.py
@@ -311,11 +311,11 @@ class BaseBitrixRobot(models.Model):
                 raise ValidationError(f"Значение '{value}' не может быть преобразовано в число.")
 
         # Если значение ни строка, ни число – выбрасываем ошибку валидации
-        raise ValidationError("Значение должно быть строкой или числом.")
+        raise ValidationError('Значение должно быть строкой или числом.')
 
     def validate_props(self) -> dict:
         """
-        Проверяет типы значений пропсовЮ которые прислал битрикс.
+        Проверяет типы значений свойств, которые прислал Битрикс.
         На данный момент проверяет только целочисленные (int) поля, которые не являются множественными.
         При наличии ошибок выбрасывает ValidationError со всеми сообщениями.
         """
@@ -330,12 +330,13 @@ class BaseBitrixRobot(models.Model):
                 if prop_type == 'int' and multiple != 'Y':
                     # Переопределяем значение в props
                     self.props[prop_name] = self.safe_int(prop_value)
+
             except ValidationError as exc:
                 errors.append(f"Ошибка в поле '{prop_name}': {exc}")
 
         if errors:
             # Если есть хотя бы одна ошибка, выбрасываем их все одним исключением
-            raise ValidationError("\n".join(errors))
+            raise ValidationError('\n'.join(errors))
 
         return self.props
 
@@ -344,7 +345,6 @@ class BaseBitrixRobot(models.Model):
         """
         Разбирает присланные данные на основании PROPERTIES
         """
-
         if self.is_hook_request:
             return self.params.get('properties', {})
 

--- a/bitrix_robots/base.py
+++ b/bitrix_robots/base.py
@@ -17,18 +17,14 @@ from integration_utils.bitrix_robots.helpers import get_php_style_list
 from settings import ilogger
 
 import django
+
 if django.VERSION[0] >= 3:
     from django.db.models import JSONField
 else:
     from django.contrib.postgres.fields import JSONField
 
-
 if TYPE_CHECKING:
     from integration_utils.bitrix24.models import BitrixUserToken, BitrixUser
-
-
-def get_error_result(exc: Exception) -> dict:
-    return dict(error=str(exc))
 
 
 class BaseBitrixRobot(models.Model):
@@ -393,7 +389,7 @@ class BaseBitrixRobot(models.Model):
             return
 
         except Exception as exc:
-            self.result = get_error_result(exc)
+            self.result = self.get_error_result(exc)
             self.is_success = False
 
             ilogger.error(
@@ -405,6 +401,10 @@ class BaseBitrixRobot(models.Model):
         self.save(update_fields=['finished', 'result', 'is_success'])
         self.send_result()
         return self.result
+
+    @staticmethod
+    def get_error_result(exc: Exception) -> dict:
+        return dict(error=str(exc))
 
     def get_return_values(self) -> dict:
         return_values = {}


### PR DESCRIPTION
Добавили по запросу Ильи заготовку для валидации параметров роботов.
Сейчас работает только валидация единичного int (то, что нужно было Илье).
При ошибке валидации кидается пояснение в результат error.

Также отформатировал файл и убрал опечатки, пока проверял.