### PR TITLE
#194747 Выделение ошибки Nginx 403 Forbidden в call_with_retries + форматирование

### DIFF
--- a/bitrix24/functions/api_call.py
+++ b/bitrix24/functions/api_call.py
@@ -35,9 +35,12 @@ class RawStringParam:
 def call_with_retries(url, converted_params,
                       retries_on_503=20, sleep_on_503_time=0.5,
                       timeout=DEFAULT_TIMEOUT, files=None):
+    """
+    Вызвать метод Битрикс в несколько попыток при неудаче.
 
-    response = None
-
+    :raises ConnectionToBitrixError: Проблема с соединением или ошибка SSL при запросе requests
+    :raises BitrixTimeout: Таймаут запроса requests
+    """
     verify = getattr(settings, 'B24API_IGNORE_SSL_VERIFICATION', True)
 
     try:

--- a/bitrix24/functions/api_call.py
+++ b/bitrix24/functions/api_call.py
@@ -56,12 +56,10 @@ def call_with_retries(url, converted_params,
             allow_redirects=False,
             verify=verify
         )
-    except requests.exceptions.SSLError as e:
+    except (requests.ConnectionError, requests.exceptions.SSLError):
         raise ConnectionToBitrixError()
     except requests.Timeout as e:
         raise BitrixTimeout(requests_timeout=e, timeout=timeout)
-    except requests.ConnectionError as e:
-        raise ConnectionToBitrixError()
     else:
         if response.status_code == 503:
             if retries_on_503 > 0:

--- a/bitrix24/functions/api_call.py
+++ b/bitrix24/functions/api_call.py
@@ -32,7 +32,7 @@ class RawStringParam:
     __repr__ = lambda self: '<RawStringParam %r>' % self.value
 
 
-def call_with_retries(url, converted_params, retry_http=False,
+def call_with_retries(url, converted_params,
                       retries_on_503=20, sleep_on_503_time=0.5,
                       timeout=DEFAULT_TIMEOUT, files=None):
 

--- a/bitrix24/functions/api_call.py
+++ b/bitrix24/functions/api_call.py
@@ -41,29 +41,18 @@ def call_with_retries(url, converted_params, retry_http=False,
     verify = getattr(settings, 'B24API_IGNORE_SSL_VERIFICATION', True)
 
     try:
-        if False: #"/crm.item." in url or "/crm.type." in url:
-            #обход бага битиркса
-            # TODO выпилить когда починят
-            # Вроде починили
-            response = requests.post(
-                "{}?{}".format(url, converted_params.decode('utf-8')),
-                converted_params,
-                auth=getattr(settings, 'B24_HTTP_BASIC_AUTH', None),
-                timeout=timeout,
-                files=files,
-                allow_redirects=False,
-                verify=verify
-            )
-        else:
-            response = requests.post(
-                url,
-                converted_params,
-                auth=getattr(settings, 'B24_HTTP_BASIC_AUTH', None),
-                timeout=timeout,
-                files=files,
-                allow_redirects=False,
-                verify=verify
-            )
+        # В истории Git есть фикс бага от 2021 года для crm.item и crm.type.
+        # Если баг снова появится - можно восстановить из Git.
+        # Дата commit-а с удалением кода фикса - 19.03.2025.
+        response = requests.post(
+            url,
+            converted_params,
+            auth=getattr(settings, 'B24_HTTP_BASIC_AUTH', None),
+            timeout=timeout,
+            files=files,
+            allow_redirects=False,
+            verify=verify
+        )
     except requests.exceptions.SSLError as e:
         raise ConnectionToBitrixError()
     except requests.Timeout as e:


### PR DESCRIPTION
Добавил вызов **BitrixApiServerError** в случае ошибки Nginx 403 Forbidden.
Сейчас эта ошибка вызывает **JsonDecodeBatchError** в batch_api_call, что не особо правильно.

Также комплексно отформатировал call_with_retries:
- Добавил комментарий с указанием вызываемых исключений.
- Убрал неиспользуемый баг-фикс от 2021 года (заменил на комментарий).
- Убрал неиспользуемый нигде параметр http_retry.