### PR TITLE
#159724 call_with_retries: Исключение, если 500 "Internal Server Error"

### DIFF
--- a/bitrix24/functions/api_call.py
+++ b/bitrix24/functions/api_call.py
@@ -10,7 +10,7 @@ import urllib
 from django.conf import settings
 from django.utils.encoding import force_str
 
-from integration_utils.bitrix24.exceptions import ConnectionToBitrixError, BitrixTimeout, BitrixApiServerError, BitrixApiError
+from integration_utils.bitrix24.exceptions import ConnectionToBitrixError, BitrixTimeout, BitrixApiServerError
 from settings import ilogger
 
 
@@ -40,7 +40,7 @@ def call_with_retries(url, converted_params,
 
     :raises ConnectionToBitrixError: Проблема с соединением или ошибка SSL при запросе requests
     :raises BitrixTimeout: Таймаут запроса requests
-    :raises BitrixApiServerError: Ошибка сервера Битрикс
+    :raises BitrixApiServerError: Ошибка HTTP-сервера Битрикс или ошибка API без JSON-ответа
     """
     verify = getattr(settings, 'B24API_IGNORE_SSL_VERIFICATION', True)
 
@@ -75,7 +75,7 @@ def call_with_retries(url, converted_params,
                 'error': 'Bitrix 500 Internal Server Error',
                 'error_description': 'Bitrix 500 Internal Server Error',
             }
-            raise BitrixApiError(has_resp=False, json_response=json_response, status_code=response.status_code, message='Bitrix 500 Internal Server Error')
+            raise BitrixApiServerError(has_resp=False, json_response=json_response, status_code=response.status_code, message='Bitrix 500 Internal Server Error')
         if response.status_code == 503:
             if retries_on_503 > 0:
                 ilogger.debug('retry_on_503=>{}'.format(pformat(dict(

--- a/bitrix24/functions/api_call.py
+++ b/bitrix24/functions/api_call.py
@@ -10,7 +10,7 @@ import urllib
 from django.conf import settings
 from django.utils.encoding import force_str
 
-from integration_utils.bitrix24.exceptions import ConnectionToBitrixError, BitrixTimeout, BitrixApiServerError
+from integration_utils.bitrix24.exceptions import ConnectionToBitrixError, BitrixTimeout, BitrixApiServerError, BitrixApiError
 from settings import ilogger
 
 
@@ -69,13 +69,13 @@ def call_with_retries(url, converted_params,
                 'error_description': 'Nginx 403 Forbidden',
             }
             raise BitrixApiServerError(has_resp=False, json_response=json_response, status_code=response.status_code, message='Nginx 403 Forbidden')
-        # Ошибка Битрикс - 500 Internal Server Error
-        if response.status_code == 500:
+        # Ошибка Битрикс - 500 Internal Server Error (не json)
+        if response.status_code == 500 and response.text == 'Internal Server Error':
             json_response = {
                 'error': 'Bitrix 500 Internal Server Error',
                 'error_description': 'Bitrix 500 Internal Server Error',
             }
-            raise BitrixApiServerError(has_resp=False, json_response=json_response, status_code=response.status_code, message='Bitrix 500 Internal Server Error')
+            raise BitrixApiError(has_resp=False, json_response=json_response, status_code=response.status_code, message='Bitrix 500 Internal Server Error')
         if response.status_code == 503:
             if retries_on_503 > 0:
                 ilogger.debug('retry_on_503=>{}'.format(pformat(dict(

--- a/bitrix24/functions/api_call.py
+++ b/bitrix24/functions/api_call.py
@@ -208,7 +208,7 @@ def convert_params(form_data):
         else:
             raise TypeError(values)
 
-        # Тут проиходит добавление вложенности ключам и рекурсивный вызов
+        # Тут происходит добавление вложенности ключам и рекурсивный вызов
         for inner_key, v in iterable:
 
             # Кодируется только вложенная часть ключа,
@@ -245,7 +245,6 @@ def api_call(domain, api_method, auth_token, params=None, webhook=False, timeout
         можно передать None, хотя возможно лучше передать просто большое
         значение, например 30 * 60 (полчаса)
 
-    :rtype: requests.Response
     :returns: Объект ответа библиотеки requests
     """
 
@@ -273,8 +272,8 @@ def api_call(domain, api_method, auth_token, params=None, webhook=False, timeout
             if operating > 300:
                 log_method = ilogger.info if operating < 400 else ilogger.warning
                 log_method('method_operating', '{}, {}: {}'.format(domain, api_method, operating))
-        except:
-            pass
+        except Exception as e:
+            ilogger.warning('method_operating_exception', repr(e))
 
     t = time.time()
 

--- a/bitrix24/functions/api_call.py
+++ b/bitrix24/functions/api_call.py
@@ -69,6 +69,13 @@ def call_with_retries(url, converted_params,
                 'error_description': 'Nginx 403 Forbidden',
             }
             raise BitrixApiServerError(has_resp=False, json_response=json_response, status_code=response.status_code, message='Nginx 403 Forbidden')
+        # Ошибка Битрикс - 500 Internal Server Error
+        if response.status_code == 500:
+            json_response = {
+                'error': 'Bitrix 500 Internal Server Error',
+                'error_description': 'Bitrix 500 Internal Server Error',
+            }
+            raise BitrixApiServerError(has_resp=False, json_response=json_response, status_code=response.status_code, message='Bitrix 500 Internal Server Error')
         if response.status_code == 503:
             if retries_on_503 > 0:
                 ilogger.debug('retry_on_503=>{}'.format(pformat(dict(


### PR DESCRIPTION
Битрикс может вернуть 500 и без JSON, просто "Internal Server Error".
На такой ответ тоже хотим бросать исключение, не отдавать response выше.