### PR TITLE
#207801 Обновление формата логов (без =>)

### DIFF
--- a/bitrix24/functions/api_call.py
+++ b/bitrix24/functions/api_call.py
@@ -78,7 +78,7 @@ def call_with_retries(url, converted_params,
             raise BitrixApiServerError(has_resp=False, json_response=json_response, status_code=response.status_code, message='Bitrix 500 Internal Server Error')
         if response.status_code == 503:
             if retries_on_503 > 0:
-                ilogger.debug('retry_on_503=>{}'.format(pformat(dict(
+                ilogger.debug('retry_on_503', '{}'.format(pformat(dict(
                     retries_left=retries_on_503,
                     url=url,
                     sleep_on_503_time=sleep_on_503_time,
@@ -93,7 +93,7 @@ def call_with_retries(url, converted_params,
                     sleep_on_503_time=sleep_on_503_time + 0.25,
                 )
             else:
-                ilogger.warn('retry_503_exceeded=>{}'.format(pformat(dict(
+                ilogger.warn('retry_503_exceeded', '{}'.format(pformat(dict(
                     url=url,
                     sleep_on_503_time=sleep_on_503_time,
                     response=response,
@@ -106,7 +106,7 @@ def call_with_retries(url, converted_params,
                 new_domain = urlparse(location).netloc
 
                 if old_domain != new_domain:
-                    ilogger.debug('retry_on_301_302=>{}'.format(pformat(dict(
+                    ilogger.debug('retry_on_301_302', '{}'.format(pformat(dict(
                         old_domain=old_domain,
                         new_domain=new_domain,
                         url=url,
@@ -122,7 +122,7 @@ def call_with_retries(url, converted_params,
                         files=files,
                     )
 
-            ilogger.warn('retry_on_301_302_failed=>{}'.format(pformat(dict(
+            ilogger.warn('retry_on_301_302_failed', '{}'.format(pformat(dict(
                 url=url,
                 location=location,
                 response=response,

--- a/bitrix24/functions/call_list_method.py
+++ b/bitrix24/functions/call_list_method.py
@@ -392,7 +392,7 @@ def call_list_method(
 
     if batch_start and time_spent > ALLOWABLE_TIME:
         # записать время выполнения в лог, если batch_api_call был вызван и выполнялся дольше 2 секунд
-        ilogger.info('call_bx_list_method_time_log=> %s' % '\n'.join(time_log))
+        ilogger.info('call_bx_list_method_time_log', '\n'.join(time_log))
 
     if allowable_error is not None and not limit:
         result_length = len(result)

--- a/its_utils/app_settings/functions.py
+++ b/its_utils/app_settings/functions.py
@@ -6,7 +6,7 @@ def set_value(key, value, comment=''):
     result = KeyValue.objects.filter(key=key).update(value=value)
     if not result:
         KeyValue.objects.create(key=key, value=value, comment=comment)
-    ilogger.debug('set_value', "{}=>{}".format(key, value))
+    ilogger.debug('set_value', '{}->{}'.format(key, value))
     return
 
 def get_value(key, create=False, default='', comment=''):


### PR DESCRIPTION
Когда-то был формат передачи в лог 1 параметра "**log_type**=>**message**".
Сейчас **log_type** и **message** должны передаваться отдельно.

Поддержку передачи 1 параметра собираемся убрать в **its_utils** (из-за ошибки с пустым log_type).
Удаление поддержки будет в ветке **[t207801_empty_log_type_problem](https://github.com/hlopikit/its_utils/compare/master...t207801_empty_log_type_problem)** в its_utils.