### PR TITLE
#221007 authenticate_on_start_application: Фикс IntegrityError

### DIFF
--- a/bitrix24/bitrix_user_auth/authenticate_on_start_application.py
+++ b/bitrix24/bitrix_user_auth/authenticate_on_start_application.py
@@ -43,16 +43,20 @@ def authenticate_on_start_application(request):
     user.save()
 
     # Получение с обновлением или создание токена пользователя
+    defaults = {
+        'auth_token': auth_token,
+        'auth_token_date': timezone.now(),
+        'refresh_token': refresh_token,
+        'refresh_error': 0,
+        'is_active': True,
+    }
+
+    if app_sid:
+        defaults['app_sid'] = app_sid
+
     bitrix_user_token, _ = BitrixUserToken.objects.update_or_create(
         user=user,
-        defaults={
-            'auth_token': auth_token,
-            'auth_token_date': timezone.now(),
-            'refresh_token': refresh_token,
-            'refresh_error': 0,
-            'is_active': True,
-            'app_sid': app_sid,
-        },
+        defaults=defaults,
     )
 
     # Информацию о пользователе и портале записать в объект request

--- a/bitrix24/bitrix_user_auth/authenticate_on_start_application.py
+++ b/bitrix24/bitrix_user_auth/authenticate_on_start_application.py
@@ -1,23 +1,20 @@
 from django.core.exceptions import PermissionDenied
-from django.db import IntegrityError
-from django.http import HttpResponse
 from django.utils import timezone
+
 from integration_utils.bitrix24.models import BitrixUserToken, BitrixUser
 
 
 def authenticate_on_start_application(request):
-
     # на базе разнообразных параметров в iframe определяет пользователя и сохраняет в request
-    #
-    #request.bitrix_user
-    #request.bitrix_user_is_new
-    #request.bitrix_user_token
+    # request.bitrix_user
+    # request.bitrix_user_is_new
+    # request.bitrix_user_token
 
     # Это для входа через IFRAME
     auth_token = request.POST.get('AUTH_ID')
     refresh_token = request.POST.get('REFRESH_ID')
     app_sid = request.GET.get('APP_SID')
-    https = request.GET.get('PROTOCOL', '1') == '1'
+    _https = request.GET.get('PROTOCOL', '1') == '1'
 
     if not auth_token and request.POST.get('auth[access_token]'):
         # Для авторизации ЧатБотов
@@ -45,35 +42,18 @@ def authenticate_on_start_application(request):
     user.user_is_active = True  # если дошел до сюда - точно активный
     user.save()
 
-    # Получение или инициализация токена из БД
-    try:
-        bitrix_user_token = BitrixUserToken.objects.get(user=user)
-    except BitrixUserToken.DoesNotExist:
-        bitrix_user_token = BitrixUserToken()
-
-    def _fill_token(but: BitrixUserToken):
-        # Заполнение полей токена
-        but.user = user
-        but.auth_token = auth_token
-
-        if refresh_token:
-            but.refresh_token = refresh_token
-
-        but.auth_token_date = timezone.now()
-        but.is_active = True
-        but.refresh_error = 0
-        if app_sid is not None:
-            but.app_sid = app_sid
-
-    _fill_token(bitrix_user_token)
-
-    try:
-        bitrix_user_token.save()
-    except IntegrityError:
-        # Случай, когда запросы накладываются друг на друга и получается два токена с одним юзером
-        bitrix_user_token = BitrixUserToken.objects.get(user=user)
-        _fill_token(bitrix_user_token)
-        bitrix_user_token.save()
+    # Получение с обновлением или создание токена пользователя
+    bitrix_user_token, _ = BitrixUserToken.objects.update_or_create(
+        user=user,
+        defaults={
+            'auth_token': auth_token,
+            'auth_token_date': timezone.now(),
+            'refresh_token': refresh_token,
+            'refresh_error': 0,
+            'is_active': True,
+            'app_sid': app_sid,
+        },
+    )
 
     # Информацию о пользователе и портале записать в объект request
     # Она будет использована в функциях, у которых есть данный декоратор

--- a/bitrix24/bitrix_user_auth/authenticate_on_start_application.py
+++ b/bitrix24/bitrix_user_auth/authenticate_on_start_application.py
@@ -46,10 +46,12 @@ def authenticate_on_start_application(request):
     defaults = {
         'auth_token': auth_token,
         'auth_token_date': timezone.now(),
-        'refresh_token': refresh_token,
         'refresh_error': 0,
         'is_active': True,
     }
+
+    if refresh_token:
+        defaults['refresh_token'] = refresh_token
 
     if app_sid:
         defaults['app_sid'] = app_sid


### PR DESCRIPTION
Была ошибка при **параллельных вызовах authenticate_on_start_application**.
По второму вызову падала IntegrityError, так как создавался второй токен по пользователю.
Сейчас поменяли логику на **update_or_create** - это должно решить "состояние гонки".