### PR TITLE
#166287 BitrixApiError: is_unauthorized_any

### DIFF
--- a/bitrix24/exceptions.py
+++ b/bitrix24/exceptions.py
@@ -191,7 +191,7 @@ class BitrixApiError(BitrixApiException):
         return self.status_code == 504
 
     @property
-    def is_unauthorized(self):
+    def is_unauthorized_any(self):
         return self.status_code == 401
 
     def dict(self):


### PR DESCRIPTION
Добавили свойство **is_unauthorized_any** для проверки любого ответа со статусом 401 Unauthorized от Битрикс.