### PR TITLE
#292029 BitrixApiError add is_mysql_query_error property

### DIFF
--- a/bitrix24/exceptions.py
+++ b/bitrix24/exceptions.py
@@ -113,6 +113,7 @@ class BitrixApiError(BitrixApiException):
             self.is_error_core,
             self.is_connection_error,
             self.is_cant_refresh,
+            self.is_mysql_query_error,
         ]):
             return True
         return False

--- a/bitrix24/exceptions.py
+++ b/bitrix24/exceptions.py
@@ -361,6 +361,10 @@ class BitrixApiError(BitrixApiException):
     def is_operation_time_limit(self):
         return self.error == 'OPERATION_TIME_LIMIT'
 
+    @property
+    def is_mysql_query_error(self):
+        return 'mysql query error' in self.error_description
+
     def dict(self):
         if isinstance(self.json_response, dict):
             error = self.json_response

--- a/bitrix24/exceptions.py
+++ b/bitrix24/exceptions.py
@@ -363,7 +363,7 @@ class BitrixApiError(BitrixApiException):
 
     @property
     def is_mysql_query_error(self):
-        return 'mysql query error' in self.error_description
+        return isinstance(self.error_description, str) and 'mysql query error' in self.error_description.lower()
 
     def dict(self):
         if isinstance(self.json_response, dict):


### PR DESCRIPTION
добавил свойство is_mysql_query_error в integration_utils.bitrix24.exceptions.BitrixApiError
Добавил это свойство в нелогические ошибки в integration_utils.bitrix24.exceptions_filter_v1.is_not_logic_error

Обрабатывает ошибки такого вида:
{'error': '', 'error_description': "Mysql query error: (1114) The table 'b_bp_workflow_user' is full"}