### PR TITLE
#301756 add is_portal_blocked_by_license_scanner property for BitrixA…

### DIFF
--- a/bitrix24/exceptions.py
+++ b/bitrix24/exceptions.py
@@ -369,6 +369,10 @@ class BitrixApiError(BitrixApiException):
 
     @property
     def is_portal_blocked_by_license_scanner(self):
+        """
+        Пример: error='PORTAL_BLOCKED_BY_LICENSE_SCANNER',
+        error_description='Portal is blocked by the license scanner.'
+        """
         return self.error == 'PORTAL_BLOCKED_BY_LICENSE_SCANNER'
 
     def dict(self):

--- a/bitrix24/exceptions.py
+++ b/bitrix24/exceptions.py
@@ -114,6 +114,7 @@ class BitrixApiError(BitrixApiException):
             self.is_connection_error,
             self.is_cant_refresh,
             self.is_mysql_query_error,
+            self.is_portal_blocked_by_license_scanner,
         ]):
             return True
         return False
@@ -365,6 +366,10 @@ class BitrixApiError(BitrixApiException):
     @property
     def is_mysql_query_error(self):
         return isinstance(self.error_description, str) and 'mysql query error' in self.error_description.lower()
+
+    @property
+    def is_portal_blocked_by_license_scanner(self):
+        return self.error == 'PORTAL_BLOCKED_BY_LICENSE_SCANNER'
 
     def dict(self):
         if isinstance(self.json_response, dict):


### PR DESCRIPTION
Добавил свойство is_portal_blocked_by_license_scanner в BitrixApiError для ошибки
{'error': 'PORTAL_BLOCKED_BY_LICENSE_SCANNER', 'error_description': 'Portal is blocked by the license scanner.'}

Добавил его в нелогические ошибки